### PR TITLE
fix: update GitHub Actions output handling

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -26,7 +26,11 @@ jobs:
       run: git submodule update --remote --recursive 
     - name: Run git status
       id: status
-      run: echo "status=$(git status -s)" >> $GITHUB_OUTPUT
+      run: |
+        status=$(git status -s)
+        echo "status<<EOF" >> $GITHUB_OUTPUT
+        echo "$status" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
     - name: Add and commit files
       run: |
         git add .


### PR DESCRIPTION
## 概要
GitHub Actions の output の扱いを修正し、最新の書き方に対応します。

## 変更内容
- deprecated な set-output の代替として $GITHUB_OUTPUT を使用
- workflow の安定性向上

## 背景
set-output コマンドが deprecated となっているため、GitHub 公式ドキュメントに従い GITHUB_OUTPUT を利用する形に変更しました。

参考:
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## 関連
Fixes #8

## 確認項目
- [ ] workflow が正常に実行される
- [ ] warning が出ない